### PR TITLE
Use /usr/bin/env to find bash instead of hard-coded path.

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -76,7 +76,7 @@ class BluetoothDevice {
 
     _call_bluetoothctl(command) {
         let btctl_command = `echo -e "${command}\\n" | bluetoothctl`;
-        Util.spawn(['/bin/bash', '-c', btctl_command]);
+        Util.spawn(['/usr/bin/env', 'bash', '-c', btctl_command]);
     }
 }
 


### PR DESCRIPTION
This makes the extension work on systems where Bash doesn't live at /bin/bash (eg NixOS).