### PR TITLE
Keep existing bluetooth airplane mode when enabling

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -95,14 +95,16 @@ class BluetoothQuickConnect {
             if (isOpen && this._autoPowerOnEnabled())
                 this._proxy.BluetoothAirplaneMode = false;
         });
-        
+
         this._connectSignal(this._model, 'row-changed', () => this._sync());
         this._connectSignal(this._model, 'row-deleted', () => this._sync());
         this._connectSignal(this._model, 'row-inserted', () => this._sync());
 
+        prevAir = this._proxy.BluetootAirplaneMode;
         this._proxy.BluetoothAirplaneMode = false;
         this._idleMonitor();
         this._sync();
+        this._proxy.BluetoothAirplaneMode = prevAir;
     }
 
     disable() {


### PR DESCRIPTION
Prevents the extension from silently leaving bluetooth enabled after load (e.g. during shell start-up/restart or extension installation/upgrade).

Also kills some trailing whitespace in the source code.