### PR TITLE
Do not force-enable BT on extension enable

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -95,14 +95,15 @@ class BluetoothQuickConnect {
             if (isOpen && this._autoPowerOnEnabled())
                 this._proxy.BluetoothAirplaneMode = false;
         });
-        
+
         this._connectSignal(this._model, 'row-changed', () => this._sync());
         this._connectSignal(this._model, 'row-deleted', () => this._sync());
         this._connectSignal(this._model, 'row-inserted', () => this._sync());
 
-        this._proxy.BluetoothAirplaneMode = false;
         this._idleMonitor();
-        this._sync();
+        if (!this._proxy.BluetoothAirplaneMode) {
+            this._sync();
+        }
     }
 
     disable() {


### PR DESCRIPTION
Prevents the extension from silently leaving bluetooth on indefinitely (or until auto poweroff) after getting enabled. Enabling the extension now preserves whatever bluetooth setting is in effect.

Also kills some trailing whitespace.