### PR TITLE
shut up JS warnings

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -18,7 +18,7 @@ const ExtensionUtils = imports.misc.extensionUtils;
 const Gio = imports.gi.Gio;
 const GioSSS = Gio.SettingsSchemaSource;
 
-class Settings {
+var Settings = class Settings {
     constructor() {
         this.settings = this._loadSettings();
     }
@@ -59,6 +59,6 @@ class Settings {
 
         let schemaObj = schemaSource.lookup(schema, true);
 
-        return new Gio.Settings({settings_schema: schemaObj});
+        return new Gio.Settings({ settings_schema: schemaObj });
     }
-}
+};

--- a/utils.js
+++ b/utils.js
@@ -34,7 +34,7 @@ function isDebugModeEnabled() {
     return new Settings().isDebugModeEnabled();
 }
 
-class Logger {
+var Logger = class Logger {
     constructor(settings) {
         this._enabled = settings.isDebugModeEnabled();
     }
@@ -44,7 +44,7 @@ class Logger {
 
         global.log(`[bluetooth-quick-connect] ${message}`);
     }
-}
+};
 
 function addSignalsHelperMethods(prototype) {
     prototype._connectSignal = function (subject, signal_name, method) {


### PR DESCRIPTION
This fixes the following two warnings on startup:

```
Nov 25 20:15:31 xps-9370 gnome-shell[1854]: Some code accessed the property 'Logger' on the module 'utils'. That property was defined with 'let' or 'const' inside the module. This was previously supported, but is not correct according to the ES6 standard. Any symbols to be exported from a module must be defined with 'var'. The property access will work as previously for the time being, but please fix your code anyway.
Nov 25 20:15:31 xps-9370 gnome-shell[1854]: Some code accessed the property 'Settings' on the module 'settings'. That property was defined with 'let' or 'const' inside the module. This was previously supported, but is not correct according to the ES6 standard. Any symbols to be exported from a module must be defined with 'var'. The property access will work as previously for the time being, but please fix your code anyway.
```

The [upstream fix](https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/1512) for the same problem has the same idea.