### PR TITLE
Fix error "assertion 'text != NULL' failed"

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -24,7 +24,8 @@ const Config = imports.misc.config;
 var PopupBluetoothDeviceMenuItem = GObject.registerClass(
     class PopupSwitchWithButtonMenuItem extends PopupMenu.PopupSwitchMenuItem {
         _init(device, params) {
-            super._init(device.name, device.isConnected, {});
+            let label = device.name || '(unknown)';
+            super._init(label, device.isConnected, {});
 
             this._device = device;
             this._showRefreshButton = params.showRefreshButton;


### PR DESCRIPTION
Whenever I had this extension enabled previously, my logs were full of messages like:
```
gnome-shell[1435]: st_label_set_text: assertion 'text != NULL' failed
```
