### PR TITLE
Use device alias if available

### DIFF
--- a/bluetooth.js
+++ b/bluetooth.js
@@ -100,7 +100,7 @@ var BluetoothDevice = class {
     }
 
     update(iter) {
-        this.name = this._model.get_value(iter, GnomeBluetooth.Column.NAME);
+        this.name = this._model.get_value(iter, GnomeBluetooth.Column.ALIAS) || this._model.get_value(iter, GnomeBluetooth.Column.NAME);
         this.isConnected = this._model.get_value(iter, GnomeBluetooth.Column.CONNECTED);
         this.isPaired = this._model.get_value(iter, GnomeBluetooth.Column.PAIRED);
         this.mac = this._model.get_value(iter, GnomeBluetooth.Column.ADDRESS);


### PR DESCRIPTION
Default to the device name if the alias is not set.