### PR TITLE
update shell version to work like a wildcard

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,9 +6,6 @@
   "settings-schema": "org.gnome.shell.extensions.bluetooth-quick-connect",
   "gettext-domain": "bluetooth-quick-connect",
   "shell-version": [
-    "40.1",
-    "40.0",
-    "40.beta",
-    "40.rc"
+    "40"
   ]
 }


### PR DESCRIPTION
Shell-version has been modified to act as the wildcard (40.*) thus avoiding having to add each Gnome update one by one. 

And avoiding the incompatible message on the gnome-extensions page.

Tested on Archlinux Gnome 40.2

You can also change the 40.0 to 40 and add 40.2 if you want each version to continue to appear individually.