### PR TITLE
Declare compatibility with GNOME Shell 41

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,6 +6,7 @@
   "settings-schema": "org.gnome.shell.extensions.bluetooth-quick-connect",
   "gettext-domain": "bluetooth-quick-connect",
   "shell-version": [
-    "40"
+    "40",
+    "41"
   ]
 }


### PR DESCRIPTION
Version 23 on
https://extensions.gnome.org/extension/1401/bluetooth-quick-connect/
seems to have received this change already.