### PR TITLE
fix: avoid zombie processes by calling spawn_close_pid

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -25,8 +25,18 @@ function spawn(command, callback) {
         null
     );
 
-    if (callback)
-        GLib.child_watch_add(GLib.PRIORITY_DEFAULT, pid, callback);
+    // ensure we always close the pid to avoid zombie processes
+    GLib.child_watch_add(
+        GLib.PRIORITY_DEFAULT, pid,
+        (_pid, _status) => {
+            try {
+                if (callback) {
+                    callback(_pid, _status);
+                }
+            } finally {
+                GLib.spawn_close_pid(_pid);
+            }
+        });
 }
 
 


### PR DESCRIPTION
I've noticed some zombie `bluetoothctl` processes in my current user session -- they seem to be caused by the extension calling `spawn_async` without `spawn_close_pid` (recommended by Glib documentation)
