### PR TITLE
[WIP] Fix/retry refresh on exception

### DIFF
--- a/bluetooth.js
+++ b/bluetooth.js
@@ -48,9 +48,9 @@ var BluetoothController = class {
 
     getDevices() {
         let adapter = this._getDefaultAdapter();
-        if (!adapter)
-            return [];
-
+        if (!adapter) {
+            throw 'No available adapter';
+        }
         let devices = [];
 
         let [ret, iter] = this._model.iter_children(adapter);
@@ -63,8 +63,16 @@ var BluetoothController = class {
         return devices;
     }
 
+    getDevicesOrEmpty() {
+        try {
+            return this.getDevices();
+        } catch {
+            return [];
+        }
+    }
+
     getConnectedDevices() {
-        return this.getDevices().filter((device) => {
+        return this.getDevicesOrEmpty().filter((device) => {
             return device.isConnected;
         });
     }

--- a/extension.js
+++ b/extension.js
@@ -186,7 +186,7 @@ class BluetoothQuickConnect {
                     1000,
                     () => {
                         this._logger.info('retrying refresh devices');
-                        _tryRefresh(count - 1);
+                        this._tryRefresh(count - 1);
                     }
                 );
             } else {

--- a/extension.js
+++ b/extension.js
@@ -162,14 +162,6 @@ class BluetoothQuickConnect {
         this._idleMonitorId = null;
     }
 
-    _connectSignal(subject, signal_name, method) {
-        let signal_id = subject.connect(signal_name, method);
-        this._signals.push({
-            subject: subject,
-            signal_id: signal_id
-        });
-    }
-
     _tryRefresh(count = 10) {
         try {
             this._logger.info('Refreshing devices list');

--- a/extension.js
+++ b/extension.js
@@ -177,7 +177,18 @@ class BluetoothQuickConnect {
                     GLib.PRIORITY_DEFAULT,
                     1000,
                     () => {
-                        this._logger.info('retrying refresh devices');
+                        this._logger.info(`Retrying refresh devices after failure caused by ${e}`);
+                        if (this._controller) {
+                            this._logger.info('Nuking the bluetooth client');
+                            this._disconnectSubjectSignals(this._controller);
+                            this._controller.destroy();
+                        }
+
+                        this._controller = new Bluetooth.BluetoothController();
+                        this._controller.enable();
+                        this._connectControllerSignals();
+
+                        this._logger.info('New controller in place. Retrying refresh');
                         this._tryRefresh(count - 1);
                     }
                 );

--- a/utils.js
+++ b/utils.js
@@ -69,7 +69,7 @@ function addSignalsHelperMethods(prototype) {
             subject: subject,
             signal_id: signal_id
         });
-    }
+    };
 
     prototype._disconnectSignals = function () {
         if (!this._signals) return;
@@ -79,4 +79,19 @@ function addSignalsHelperMethods(prototype) {
         });
         this._signals = [];
     };
+
+    prototype._disconnectSubjectSignals = function(subject) {
+        if (!this._signals) return;
+
+        const newSignalList = [];
+        this._signals.forEach( signal => {
+            if (signal.subject == subject) {
+                signal.subject.disconnect(signal.signal_id);
+            } else {
+                newSignalList.push(signal);
+            }
+        });
+
+        this._signals = newSignalList;
+    }
 }

--- a/utils.js
+++ b/utils.js
@@ -83,15 +83,14 @@ function addSignalsHelperMethods(prototype) {
     prototype._disconnectSubjectSignals = function(subject) {
         if (!this._signals) return;
 
-        const newSignalList = [];
-        this._signals.forEach( signal => {
+        this._signals = this._signals.filter( signal => {
             if (signal.subject == subject) {
                 signal.subject.disconnect(signal.signal_id);
-            } else {
-                newSignalList.push(signal);
-            }
-        });
 
-        this._signals = newSignalList;
+                return false;
+            }
+
+            return true;
+        });
     }
 }


### PR DESCRIPTION
After upgrading to Fedora 35, I've noticed that after suspension or long periods with the screen locked, the extension would not reload properly -- no device would show in the menu.

I have observed that on such occasions there would be some message like`Could not create bluez object manager: GDBus.Error:org.freedesktop.DBus.Error.NoReply: Remote peer disconnected`

Further debugging has shown that
- `bluetooth.service` restarts with `Disconnected from D-Bus. Exiting.`
- `BluetoothController::_getDefaultAdapter` would return null
- no new signals arrive at the extension

The restarting of bluez seems to happen every suspend/resume and when the screen remains locked for some time.

It seems to be a race condition where the extension instantiates a client that holds a reference to an instance that's about to be killed, and the client does not check the bus for a new instance afterwards.

I implemented this workaround that tries to reconnect on such occasions, but I'm not very happy with it... what happens when the daemon restarts mid-session? Will the extension receive any signal that can eventually trigger a `refresh`?

(a few tests here have shown that the client will happily point to the new instance in this last case and behaves normally)

I left the MR in [WIP] to discuss if there's some more robust sollution.
