### PR TITLE
Be compatible with GNOME Shell 42

### DIFF
--- a/bluetooth.js
+++ b/bluetooth.js
@@ -31,7 +31,12 @@ var BluetoothController = class {
         this._connectSignal(this._model, 'row-changed', (arg0, arg1, iter) => {
             if (iter) {
                 let device = this._buildDevice(iter);
-                this.emit('device-changed', device);
+                if (device.isDefault) {
+                    this.emit('default-adapter-changed', device);
+                }
+                else {
+                    this.emit('device-changed', device);
+                }
             }
 
         });

--- a/bluetooth.js
+++ b/bluetooth.js
@@ -24,45 +24,46 @@ const Utils = Me.imports.utils;
 var BluetoothController = class {
     constructor() {
         this._client = new GnomeBluetooth.Client();
-        this._model = this._client.get_model();
+        this._deviceNotifyConnected = new Set();
+        this._store = this._client.get_devices();
     }
 
     enable() {
-        this._connectSignal(this._model, 'row-changed', (arg0, arg1, iter) => {
-            if (iter) {
-                let device = this._buildDevice(iter);
-                if (device.isDefault) {
-                    this.emit('default-adapter-changed', device);
-                }
-                else {
-                    this.emit('device-changed', device);
-                }
-            }
-
+        this._client.connect('notify::default-adapter', () => {
+            this._deviceNotifyConnected.clear();
+            this.emit('default-adapter-changed');
         });
-        this._connectSignal(this._model, 'row-deleted', () => {
+        this._client.connect('notify::default-adapter-powered', () => {
+            this._deviceNotifyConnected.clear();
+            this.emit('default-adapter-changed');
+        });
+        this._client.connect('device-removed', (c, path) => {
+            this._deviceNotifyConnected.delete(path);
             this.emit('device-deleted');
         });
-        this._connectSignal(this._model, 'row-inserted', (arg0, arg1, iter) => {
-            if (iter) {
-                let device = this._buildDevice(iter);
-                this.emit('device-inserted', device);
-            }
+        this._client.connect('device-added', (c, device) => {
+            this._connectDeviceNotify(device);
+            this.emit('device-inserted', new BluetoothDevice(device));
+        });
+    }
+
+    _connectDeviceNotify(device) {
+        const path = device.get_object_path();
+
+        if (this._deviceNotifyConnected.has(path))
+            return;
+
+        device.connect('notify', (device) => {
+            this.emit('device-changed', new BluetoothDevice(device));
         });
     }
 
     getDevices() {
-        let adapter = this._getDefaultAdapter();
-        if (!adapter)
-            return [];
-
         let devices = [];
 
-        let [ret, iter] = this._model.iter_children(adapter);
-        while (ret) {
-            let device = this._buildDevice(iter);
+        for (let i = 0; i < this._store.get_n_items(); i++) {
+            let device = new BluetoothDevice(this._store.get_item(i));
             devices.push(device);
-            ret = this._model.iter_next(iter);
         }
 
         return devices;
@@ -77,39 +78,21 @@ var BluetoothController = class {
     destroy() {
         this._disconnectSignals();
     }
-
-    _getDefaultAdapter() {
-        let [ret, iter] = this._model.get_iter_first();
-        while (ret) {
-            let isDefault = this._model.get_value(iter, GnomeBluetooth.Column.DEFAULT);
-            let isPowered = this._model.get_value(iter, GnomeBluetooth.Column.POWERED);
-            if (isDefault && isPowered)
-                return iter;
-            ret = this._model.iter_next(iter);
-        }
-        return null;
-    }
-
-    _buildDevice(iter) {
-        return new BluetoothDevice(this._model, iter);
-    }
 }
 
 Signals.addSignalMethods(BluetoothController.prototype);
 Utils.addSignalsHelperMethods(BluetoothController.prototype);
 
 var BluetoothDevice = class {
-    constructor(model, iter) {
-        this._model = model;
-        this.update(iter);
+    constructor(dev) {
+        this.update(dev);
     }
 
-    update(iter) {
-        this.name = this._model.get_value(iter, GnomeBluetooth.Column.ALIAS) || this._model.get_value(iter, GnomeBluetooth.Column.NAME);
-        this.isConnected = this._model.get_value(iter, GnomeBluetooth.Column.CONNECTED);
-        this.isPaired = this._model.get_value(iter, GnomeBluetooth.Column.PAIRED);
-        this.mac = this._model.get_value(iter, GnomeBluetooth.Column.ADDRESS);
-        this.isDefault = this._model.get_value(iter, GnomeBluetooth.Column.DEFAULT);
+    update(dev) {
+        this.name = dev.alias || dev.name;
+        this.isConnected = dev.connected;
+        this.isPaired = dev.paired;
+        this.mac = dev.address;
     }
 
     disconnect() {

--- a/extension.js
+++ b/extension.js
@@ -82,6 +82,11 @@ class BluetoothQuickConnect {
     _connectControllerSignals() {
         this._logger.info('Connecting bluetooth controller signals');
 
+        this._connectSignal(this._controller, 'default-adapter-changed', (ctrl) => {
+            this._logger.info('Default adapter changed event');
+            this._refresh();
+        });
+
         this._connectSignal(this._controller, 'device-inserted', (ctrl, device) => {
             this._logger.info(`Device inserted event: ${device.name}`);
             if (device.isPaired) {
@@ -93,9 +98,7 @@ class BluetoothQuickConnect {
 
         this._connectSignal(this._controller, 'device-changed', (ctrl, device) => {
             this._logger.info(`Device changed event: ${device.name}`);
-            if (device.isDefault)
-                this._refresh();
-            else if (device.isPaired)
+            if (device.isPaired)
                 this._syncMenuItem(device);
             else
                 this._logger.info(`Skipping change event for unpaired device ${device.name}`);

--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,6 @@
   "settings-schema": "org.gnome.shell.extensions.bluetooth-quick-connect",
   "gettext-domain": "bluetooth-quick-connect",
   "shell-version": [
-    "40",
-    "41"
+    "42"
   ]
 }

--- a/power.js
+++ b/power.js
@@ -3,7 +3,7 @@ const UPower = imports.gi.UPowerGlib;
 const Me = ExtensionUtils.getCurrentExtension();
 const Utils = Me.imports.utils;
 
-class UPowerBatteryProvider {
+var UPowerBatteryProvider = class {
     constructor(logger) {
         this._upower_client = UPower.Client.new();
         this._logger = logger;


### PR DESCRIPTION
* power: Use var syntax to export object
    
    As per <https://gjs.guide/guides/gjs/intro.html#imports-and-modules>.
    This seems to be required by GNOME Shell 42 (gjs 1.72).

* bluetooth: Use a separate signal for changes to the default adapter
    
    In gnome-bluetooth API version 1.0 (GNOME 41 and older), the Bluetooth
    adapters are part of the same GtkTreeModel as the devices attached to
    them, but in gnome-bluetooth API version 3.0 (GNOME 42) they're tracked
    separately.

* bluetooth: Use GListStore for GNOME Shell 42
    
    GNOME 42 has a new version of the GnomeBluetooth library, with a
    different API. Adjust to this.
    
    Resolves: https://github.com/bjarosze/gnome-bluetooth-quick-connect/issues/53

---

The first commit resolves the error message initially reported on #53, and the second and third commits fix compatibility with newer gnome-bluetooth. I've left the old code paths in place, so this *should* continue to be compatible with v41 as well (untested).