### PR TITLE
Battery info layout

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -259,7 +259,7 @@ var PopupBluetoothDeviceMenuItem = GObject.registerClass(
 var BatteryInfoWidget = GObject.registerClass(
     class BatteryInfoWidget extends St.BoxLayout {
         _init(showBatteryValue, showBatteryIcon) {
-            super._init({ visible: false });
+            super._init({ visible: false, style: 'spacing: 3px;' });
             this._icon = new St.Icon({ style_class: 'popup-menu-icon' });
             this.add_child(this._icon);
             this._icon.icon_name = null;

--- a/ui.js
+++ b/ui.js
@@ -266,12 +266,16 @@ var BatteryInfoWidget = GObject.registerClass(
 
             // dirty trick: instantiate the label with text 100%, so we can set
             // the natural width of the label in case monospace has no effect
-            this._label = new St.Label({ y_expand: false, style_class: 'monospace', text: '100%' });
+            this._label = new St.Label({
+                x_align: Clutter.ActorAlign.START,
+                y_align: Clutter.ActorAlign.CENTER,
+                style_class: 'monospace',
+                text: '100%'
+            });
+
             this._label.natural_width = this._label.width;
             this._label.text = "";
 
-            this._label.x_expand = false;
-            this._label.x_align = Clutter.ActorAlign.LEFT;
             this.add_child(this._label);
 
             if (!showBatteryValue) this._label.hide();


### PR DESCRIPTION
- Fixes #70
- Center battery value vertically.
- Add 3px between battery icon and value, as it looks more consistent with the other shell elements.

Before :

![Capture d’écran du 2023-02-05 01-17-30](https://user-images.githubusercontent.com/12450010/216819490-65d7f81a-389b-41d0-b87c-fafd26042ed7.png)

After :

![Capture d’écran du 2023-02-05 01-15-34](https://user-images.githubusercontent.com/12450010/216819501-bd340e1f-b517-4237-8653-27567f8a1476.png)
