### PR TITLE
Added device icons if they are present

### DIFF
--- a/bluetooth.js
+++ b/bluetooth.js
@@ -90,6 +90,7 @@ var BluetoothDevice = class {
 
     update(dev) {
         this.name = dev.alias || dev.name;
+        this.icon = dev.icon;
         this.isConnected = dev.connected;
         this.isPaired = dev.paired;
         this.mac = dev.address;

--- a/ui.js
+++ b/ui.js
@@ -32,6 +32,7 @@ var PopupBluetoothDeviceMenuItem = GObject.registerClass(
         _init(device, batteryProvider, logger, params) {
             let label = device.name || '(unknown)';
             super._init(label, device.isConnected, {});
+            this._handleIcon(device);
 
             this._logger = logger;
 
@@ -58,6 +59,16 @@ var PopupBluetoothDeviceMenuItem = GObject.registerClass(
             this.add_child(this._pendingLabel);
 
             this.sync(device);
+        }
+
+        _handleIcon(device) {
+            if (!device.icon) return;
+
+            let deviceIcon = new St.Icon({
+                style_class: "popup-menu-icon",
+                icon_name: device.icon,
+            });
+            this.insert_child_at_index(deviceIcon, 1);
         }
 
         _tryLocateBatteryWithTimeout(count = 10) {


### PR DESCRIPTION
Hi and many thanks for this awesome extension!

Since last year my bluetooth devices number increased and your extension was very useful. 
I even find it better than the default Bluetooth QuickSettings from Gnome 44 :sweat_smile: 

Since I upgraded to 44 I saw that each device has a nice icon depending on its type. 
This pull request adds the device icons if they are present.

The quick panel should now look something like this:
![Screenshot from 2023-05-11 20-57-05](https://github.com/bjarosze/gnome-bluetooth-quick-connect/assets/5013697/36b0b37d-70af-4d37-98bf-840429acd84c)

Thanks!